### PR TITLE
Add Bignum to the allowed types for the "id" field.

### DIFF
--- a/lib/jimson/server.rb
+++ b/lib/jimson/server.rb
@@ -111,7 +111,7 @@ module Jimson
                          'jsonrpc' => [String],
                          'method'  => [String], 
                          'params'  => [Hash, Array],
-                         'id'      => [String, Fixnum, NilClass]
+                         'id'      => [String, Fixnum, Bignum, NilClass]
                        }
       
       return false if !request.is_a?(Hash)


### PR DESCRIPTION
The JSON-RPC spec says this about the "id" field:  "The request id. This
can be of any type."

The particular issue I was running into is that the client uses
rand(10**12) to generate the id.  That overflows a Fixnum on a 32 bit
box (my linode in this case), leading to a Bignum.

Since JSON allows any form of number we should probably do something
more like a kind_of?(Numeric), but I'll leave it to someone else to make
more significant changes.
